### PR TITLE
Adds missing test dep

### DIFF
--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -32,6 +32,7 @@
   <test_depend>actionlib_msgs</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>builtin_interfaces</test_depend>
+  <test_depend>unique_identifier_msgs</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
   <test_depend>example_interfaces</test_depend>
   <test_depend>geometry_msgs</test_depend>


### PR DESCRIPTION
Was causing build failure on truck due to missing test dependency.